### PR TITLE
Fix mobile SVG rendering

### DIFF
--- a/script.js
+++ b/script.js
@@ -11,13 +11,11 @@ const svgCache = {};
 function getSvgImage(key, svgText) {
   if (!svgCache[key]) {
     const blob = new Blob([svgText], { type: 'image/svg+xml' });
-    const url = URL.createObjectURL(blob);
-    const img = new Image();
-    img.src = url;
-    img.onload = () => URL.revokeObjectURL(url);
-    svgCache[key] = img;
+    svgCache[key] = URL.createObjectURL(blob);
   }
-  return svgCache[key].cloneNode();
+  const img = new Image();
+  img.src = svgCache[key];
+  return img;
 }
 
 // ==== SVG データ ====


### PR DESCRIPTION
## Summary
- fix SVG caching to avoid revoking object URLs before clones load, preventing missing sprites on mobile devices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b68c2ed40833095290788fc494bfb