### PR TITLE
feat: expand sprites and enemy variety

### DIFF
--- a/script.js
+++ b/script.js
@@ -33,6 +33,18 @@ const ENEMY_STRONG_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 6
   <ellipse cx="30" cy="25" rx="25" ry="10" fill="#27ae60"/>
   <ellipse cx="30" cy="12" rx="15" ry="8" fill="#2ecc71"/>
 </svg>`;
+const ENEMY_FAST_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 30">
+  <ellipse cx="25" cy="15" rx="20" ry="10" fill="#9b59b6"/>
+  <circle cx="25" cy="15" r="5" fill="#8e44ad"/>
+</svg>`;
+const ENEMY_SHOOTER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 40">
+  <rect x="5" y="10" width="50" height="20" fill="#f1c40f" rx="5"/>
+  <circle cx="30" cy="20" r="6" fill="#f39c12"/>
+</svg>`;
+const ITEM_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 40">
+  <circle cx="20" cy="20" r="18" fill="gold"/>
+  <polygon points="20,5 23,15 35,15 25,22 28,32 20,26 12,32 15,22 5,15 17,15" fill="orange"/>
+</svg>`;
 
 let playerY = window.innerHeight / 2;
 const speed = 5;
@@ -198,30 +210,102 @@ function spawnHoming() {
   }, 20);
 }
 
-// ==== 敵生成（2種類） ====
+function spawnEnemyBullet(x, y, speed = 6) {
+  const bullet = document.createElement('div');
+  bullet.classList.add('enemy-bullet');
+  bullet.style.left = `${x}px`;
+  bullet.style.top = `${y - 4}px`;
+  gameContainer.appendChild(bullet);
+  const interval = setInterval(() => {
+    const currentLeft = parseInt(bullet.style.left, 10);
+    if (gameOver || currentLeft < -20) {
+      bullet.remove();
+      clearInterval(interval);
+    } else {
+      bullet.style.left = `${currentLeft - speed}px`;
+      checkEnemyBulletCollision(bullet, interval);
+    }
+  }, 20);
+}
+
+function checkEnemyBulletCollision(bullet, interval) {
+  const playerRect = player.getBoundingClientRect();
+  const bulletRect = bullet.getBoundingClientRect();
+  if (
+    bulletRect.left < playerRect.right &&
+    bulletRect.right > playerRect.left &&
+    bulletRect.top < playerRect.bottom &&
+    bulletRect.bottom > playerRect.top
+  ) {
+    bullet.remove();
+    clearInterval(interval);
+    if (barrierHits > 0) {
+      barrierHits--;
+      if (barrierHits <= 0) {
+        const b = player.querySelector('.barrier');
+        if (b) b.remove();
+      }
+    } else {
+      createExplosion(player.offsetLeft, player.offsetTop);
+      endGame();
+    }
+  }
+}
+
+// ==== 敵生成（4種類） ====
 function spawnEnemy() {
   if (gameOver) return;
-  const type = Math.random() < 0.5 ? 'enemy' : 'enemy-strong';
+  const types = ['enemy', 'enemy-strong', 'enemy-fast', 'enemy-shooter'];
+  const type = types[Math.floor(Math.random() * types.length)];
   const enemy = document.createElement('div');
   enemy.classList.add(type);
-  enemy.appendChild(
-    getSvgImage(
-      type,
-      type === 'enemy' ? ENEMY_SVG : ENEMY_STRONG_SVG
-    )
-  );
-  const enemyY = Math.random() * (window.innerHeight - 50);
+  const svgMap = {
+    'enemy': ENEMY_SVG,
+    'enemy-strong': ENEMY_STRONG_SVG,
+    'enemy-fast': ENEMY_FAST_SVG,
+    'enemy-shooter': ENEMY_SHOOTER_SVG
+  };
+  enemy.appendChild(getSvgImage(type, svgMap[type]));
   enemy.style.left = `${window.innerWidth}px`;
-  enemy.style.top = `${enemyY}px`;
   gameContainer.appendChild(enemy);
+  enemy.style.top = `${Math.random() * (window.innerHeight - enemy.offsetHeight)}px`;
+
+  let speedX = 3;
+  let shootInterval = null;
+  if (type === 'enemy-strong') {
+    speedX = 2;
+    shootInterval = setInterval(() => {
+      spawnEnemyBullet(enemy.offsetLeft, enemy.offsetTop + enemy.offsetHeight / 2, 6);
+    }, 1500);
+  } else if (type === 'enemy-fast') {
+    speedX = 6;
+    enemy.dataset.vy = '3';
+  } else if (type === 'enemy-shooter') {
+    speedX = 2;
+    shootInterval = setInterval(() => {
+      spawnEnemyBullet(enemy.offsetLeft, enemy.offsetTop + enemy.offsetHeight / 2, 8);
+    }, 1000);
+  }
+  if (shootInterval) enemy.shootInterval = shootInterval;
 
   const moveInterval = setInterval(() => {
     const currentLeft = parseInt(enemy.style.left, 10);
-    if (gameOver || currentLeft < -50) {
+    if (gameOver || currentLeft < -enemy.offsetWidth) {
       enemy.remove();
       clearInterval(moveInterval);
+      if (shootInterval) clearInterval(shootInterval);
     } else {
-      enemy.style.left = `${currentLeft - 3}px`;
+      enemy.style.left = `${currentLeft - speedX}px`;
+      if (enemy.dataset.vy) {
+        let vy = parseInt(enemy.dataset.vy, 10);
+        let newTop = parseInt(enemy.style.top, 10) + vy;
+        if (newTop <= 0 || newTop >= window.innerHeight - enemy.offsetHeight) {
+          vy = -vy;
+          enemy.dataset.vy = vy.toString();
+          newTop = parseInt(enemy.style.top, 10) + vy;
+        }
+        enemy.style.top = `${newTop}px`;
+      }
       checkPlayerCollision(enemy, moveInterval);
     }
   }, 20);
@@ -230,7 +314,7 @@ function spawnEnemy() {
 
 // ==== 弾と敵の衝突判定 ====
 function checkBulletCollision(bullet, interval, type) {
-  const enemies = document.querySelectorAll('.enemy, .enemy-strong');
+  const enemies = document.querySelectorAll('.enemy, .enemy-strong, .enemy-fast, .enemy-shooter');
   const bulletRect = bullet.getBoundingClientRect();
 
   enemies.forEach(enemy => {
@@ -242,8 +326,14 @@ function checkBulletCollision(bullet, interval, type) {
       bulletRect.bottom > enemyRect.top
     ) {
       createExplosion(enemy.offsetLeft, enemy.offsetTop);
+      if (enemy.shootInterval) clearInterval(enemy.shootInterval);
       enemy.remove();
-      updateScore(enemy.classList.contains('enemy-strong') ? 200 : 100);
+      const points = enemy.classList.contains('enemy-strong') || enemy.classList.contains('enemy-shooter')
+        ? 200
+        : enemy.classList.contains('enemy-fast')
+          ? 150
+          : 100;
+      updateScore(points);
       enemiesDestroyed++;
       checkStageProgress();
       if (type !== 'beam') {
@@ -266,6 +356,7 @@ function checkPlayerCollision(enemy, interval) {
     playerRect.bottom > enemyRect.top
   ) {
     createExplosion(enemy.offsetLeft, enemy.offsetTop);
+    if (enemy.shootInterval) clearInterval(enemy.shootInterval);
     enemy.remove();
     clearInterval(interval);
     if (barrierHits > 0) {
@@ -287,11 +378,12 @@ function spawnItem() {
   const item = document.createElement('div');
   item.classList.add('item');
   item.style.left = `${window.innerWidth}px`;
-  item.style.top = `${Math.random() * (window.innerHeight - 20)}px`;
+  item.appendChild(getSvgImage('item', ITEM_SVG));
   gameContainer.appendChild(item);
+  item.style.top = `${Math.random() * (window.innerHeight - item.offsetHeight)}px`;
   const move = setInterval(() => {
     const currentLeft = parseInt(item.style.left, 10);
-    if (gameOver || currentLeft < -20) {
+    if (gameOver || currentLeft < -item.offsetWidth) {
       item.remove();
       clearInterval(move);
     } else {
@@ -331,7 +423,7 @@ function activateBarrier() {
 }
 
 function findNearestEnemy(x, y) {
-  const enemies = document.querySelectorAll('.enemy, .enemy-strong');
+  const enemies = document.querySelectorAll('.enemy, .enemy-strong, .enemy-fast, .enemy-shooter');
   let nearest = null;
   let dist = Infinity;
   enemies.forEach(enemy => {

--- a/style.css
+++ b/style.css
@@ -53,8 +53,8 @@ body {
     left: 50px;
     top: 50%;
     transform: translateY(-50%);
-    width: 120px;
-    height: 80px;
+    width: 240px;
+    height: 160px;
     z-index: 5;
   }
   #player img {
@@ -76,20 +76,20 @@ body {
     background: cyan;
   }
   
-.enemy, .enemy-strong {
+.enemy, .enemy-strong, .enemy-fast, .enemy-shooter {
     position: absolute;
     border-radius: 5px;
     overflow: hidden;
   }
-.enemy {
-    width: 40px;
-    height: 30px;
+.enemy, .enemy-fast {
+    width: 80px;
+    height: 60px;
   }
-.enemy-strong {
-    width: 50px;
-    height: 40px;
+.enemy-strong, .enemy-shooter {
+    width: 100px;
+    height: 80px;
   }
-.enemy img, .enemy-strong img {
+.enemy img, .enemy-strong img, .enemy-fast img, .enemy-shooter img {
     width: 100%;
     height: 100%;
     display: block;
@@ -145,10 +145,13 @@ body {
 
   .item {
     position: absolute;
-    width: 20px;
-    height: 20px;
-    background: gold;
-    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+  }
+  .item img {
+    width: 100%;
+    height: 100%;
+    display: block;
   }
 
   .beam {
@@ -170,10 +173,17 @@ body {
     position: absolute;
     top: -10px;
     left: -10px;
-    width: 140px;
-    height: 100px;
+    width: 260px;
+    height: 180px;
     border: 3px solid cyan;
     border-radius: 50%;
     pointer-events: none;
+  }
+
+  .enemy-bullet {
+    position: absolute;
+    width: 20px;
+    height: 8px;
+    background: red;
   }
   


### PR DESCRIPTION
## Summary
- scale player and enemy sprites to 200%
- swap plain item for star-shaped SVG pickup
- add two new enemy types with unique movement and shooting attacks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688d82975b448330b437e8d658ae48c7