### PR TITLE
Use fighter jet svg for player

### DIFF
--- a/images/player.svg
+++ b/images/player.svg
@@ -1,5 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
-  <polygon points="10,30 70,18 110,30 70,42" fill="#3498db" stroke="#2980b9" stroke-width="2"/>
-  <polygon points="50,20 80,30 50,40" fill="#bdc3c7"/>
-  <polygon points="20,15 45,30 20,45" fill="#ecf0f1"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80">
+  <defs>
+    <linearGradient id="bodyGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="100%" stop-color="#00f2fe"/>
+    </linearGradient>
+    <linearGradient id="wingGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#43e97b"/>
+      <stop offset="100%" stop-color="#38f9d7"/>
+    </linearGradient>
+  </defs>
+  <polygon points="60,5 85,40 60,75 35,40" fill="url(#bodyGrad)" stroke="#ffffff" stroke-width="2"/>
+  <polygon points="5,33 60,23 115,33 115,47 60,57 5,47" fill="url(#wingGrad)" stroke="#ffffff" stroke-width="2"/>
+  <ellipse cx="60" cy="40" rx="10" ry="14" fill="#ffffff" opacity="0.6" stroke="#ffffff" stroke-width="1"/>
+  <polygon points="53,60 67,60 72,75 48,75" fill="url(#bodyGrad)" stroke="#ffffff" stroke-width="2"/>
 </svg>

--- a/script.js
+++ b/script.js
@@ -20,16 +20,21 @@ function getSvgImage(key, svgText) {
 }
 
 // ==== SVG データ ====
-const PLAYER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+const PLAYER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 80">
   <defs>
-    <linearGradient id="playerGrad" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#00c6ff"/>
-      <stop offset="100%" stop-color="#0072ff"/>
+    <linearGradient id="bodyGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4facfe"/>
+      <stop offset="100%" stop-color="#00f2fe"/>
+    </linearGradient>
+    <linearGradient id="wingGrad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#43e97b"/>
+      <stop offset="100%" stop-color="#38f9d7"/>
     </linearGradient>
   </defs>
-  <polygon points="10,30 60,5 110,30 60,55" fill="url(#playerGrad)" stroke="#ffffff" stroke-width="2"/>
-  <polygon points="60,15 80,30 60,45 40,30" fill="#ffffff" opacity="0.6"/>
-  <circle cx="60" cy="30" r="6" fill="#f1c40f"/>
+  <polygon points="60,5 85,40 60,75 35,40" fill="url(#bodyGrad)" stroke="#ffffff" stroke-width="2"/>
+  <polygon points="5,33 60,23 115,33 115,47 60,57 5,47" fill="url(#wingGrad)" stroke="#ffffff" stroke-width="2"/>
+  <ellipse cx="60" cy="40" rx="10" ry="14" fill="#ffffff" opacity="0.6" stroke="#ffffff" stroke-width="1"/>
+  <polygon points="53,60 67,60 72,75 48,75" fill="url(#bodyGrad)" stroke="#ffffff" stroke-width="2"/>
 </svg>`;
 const ENEMY_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 40">
   <defs>


### PR DESCRIPTION
## Summary
- Replace simple player graphic with a gradient styled fighter jet SVG
- Update player asset file to match new design

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688da26f99c08330afe3f22c14d14127