### PR TITLE
Add boss battle with 60s countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     <div id="background"></div>
     <div id="score">Score: 0</div>
     <div id="stage">Stage: 1</div>
+    <div id="countdown"></div>
     <div id="player"></div>
     <div id="game-over">GAME OVER</div>
     <audio id="bgm" src="audio/battle_bgm.mp3" loop></audio>

--- a/style.css
+++ b/style.css
@@ -82,7 +82,7 @@ body {
     background: cyan;
   }
   
-.enemy, .enemy-strong, .enemy-fast, .enemy-shooter {
+.enemy, .enemy-strong, .enemy-fast, .enemy-shooter, .boss {
     position: absolute;
     border-radius: 5px;
     overflow: hidden;
@@ -95,7 +95,11 @@ body {
     width: 100px;
     height: 80px;
   }
-.enemy img, .enemy-strong img, .enemy-fast img, .enemy-shooter img {
+.boss {
+    width: 320px;
+    height: 240px;
+  }
+.enemy img, .enemy-strong img, .enemy-fast img, .enemy-shooter img, .boss img {
     width: 100%;
     height: 100%;
     display: block;
@@ -134,6 +138,14 @@ body {
     position: absolute;
     top: 40px;
     left: 20px;
+    font-size: 20px;
+    z-index: 10;
+  }
+
+  #countdown {
+    position: absolute;
+    top: 10px;
+    right: 20px;
     font-size: 20px;
     z-index: 10;
   }


### PR DESCRIPTION
## Summary
- Display countdown until boss appears
- Spawn a 400% sized boss after 60 seconds and pause normal enemies
- Handle boss collisions and resume game after defeat

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eeaf3ea18833096133d532765ca41