### PR TITLE
Scale player to 70% and intensify beam visuals

### DIFF
--- a/script.js
+++ b/script.js
@@ -219,7 +219,7 @@ function shoot(type = 'normal') {
 function spawnBullet(centerY) {
   const bullet = document.createElement('div');
   bullet.classList.add('bullet');
-  bullet.style.left = `${player.offsetLeft + player.offsetWidth - 50}px`;
+  bullet.style.left = `${player.offsetLeft + player.offsetWidth - 35}px`;
   gameContainer.appendChild(bullet);
   bullet.style.top = `${centerY - bullet.offsetHeight / 2}px`;
   const interval = setInterval(() => {
@@ -237,7 +237,7 @@ function spawnBullet(centerY) {
 function spawnBeam() {
   const beam = document.createElement('div');
   beam.classList.add('beam');
-  beam.style.left = `${player.offsetLeft + player.offsetWidth - 50}px`;
+  beam.style.left = `${player.offsetLeft + player.offsetWidth - 35}px`;
   gameContainer.appendChild(beam);
   beam.style.top = `${player.offsetTop + player.offsetHeight / 2 - beam.offsetHeight / 2}px`;
   const interval = setInterval(() => {
@@ -246,7 +246,7 @@ function spawnBeam() {
       beam.remove();
       clearInterval(interval);
     } else {
-      beam.style.left = `${currentLeft + 12}px`;
+      beam.style.left = `${currentLeft + 16}px`;
       checkBulletCollision(beam, interval, 'beam');
     }
   }, 16);
@@ -255,7 +255,7 @@ function spawnBeam() {
 function spawnHoming() {
   const bullet = document.createElement('div');
   bullet.classList.add('homing');
-  bullet.style.left = `${player.offsetLeft + player.offsetWidth - 50}px`;
+  bullet.style.left = `${player.offsetLeft + player.offsetWidth - 35}px`;
   gameContainer.appendChild(bullet);
   bullet.style.top = `${player.offsetTop + player.offsetHeight / 2 - bullet.offsetHeight / 2}px`;
   const interval = setInterval(() => {

--- a/style.css
+++ b/style.css
@@ -64,8 +64,8 @@ body {
     left: 50px;
     top: 50%;
     transform: translateY(-50%);
-    width: 240px;
-    height: 160px;
+    width: 168px;
+    height: 112px;
     z-index: 5;
   }
   #player img {
@@ -179,9 +179,17 @@ body {
 
   .beam {
     position: absolute;
-    width: 120px;
-    height: 12px;
-    background: lime;
+    width: 200px;
+    height: 16px;
+    background: linear-gradient(90deg, rgba(255,255,255,0.9), #0ff, rgba(255,255,255,0.9));
+    box-shadow: 0 0 8px #0ff, 0 0 16px #0ff, 0 0 24px #0ff;
+    border-radius: 8px;
+    animation: beamGlow 0.3s alternate infinite;
+  }
+
+  @keyframes beamGlow {
+    from { box-shadow: 0 0 8px #0ff, 0 0 16px #0ff, 0 0 24px #0ff; }
+    to { box-shadow: 0 0 16px #0ff, 0 0 32px #0ff, 0 0 48px #0ff; }
   }
 
   .homing {
@@ -196,8 +204,8 @@ body {
     position: absolute;
     top: -10px;
     left: -10px;
-    width: 260px;
-    height: 180px;
+    width: 188px;
+    height: 132px;
     border: 3px solid cyan;
     border-radius: 50%;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- Shrink player sprite to 70% with matching barrier resize
- Amp up beam with glowing gradient and faster movement
- Adjust projectile spawn points for new ship size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68913b018bcc8330b4d2c8f30976b6c6