### PR TITLE
Add game over sequence and restart functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,14 @@
     <div id="score">Score: 0</div>
     <div id="stage">Stage: 1</div>
     <div id="countdown"></div>
+    <div id="overlay"></div>
     <div id="player"></div>
-    <div id="game-over">GAME OVER</div>
+    <div id="game-over">
+      <div id="game-over-text">GAME OVER</div>
+      <div id="final-score"></div>
+      <button id="restart-button">再挑戦</button>
+      <button id="title-button">タイトルに戻る</button>
+    </div>
     <audio id="bgm" loop></audio>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ body {
   
   #player {
     position: absolute;
-    left: 50px;
+    left: 150px;
     top: 50%;
     transform: translateY(-50%);
     width: 168px;
@@ -141,8 +141,9 @@ body {
 
   #stage {
     position: absolute;
-    top: 40px;
-    left: 20px;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
     font-size: 20px;
     z-index: 10;
   }
@@ -158,12 +159,57 @@ body {
   #game-over {
     display: none;
     position: absolute;
-    top: 40%;
+    top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    font-size: 48px;
     color: red;
     z-index: 20;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  #game-over-text {
+    font-size: 64px;
+    animation: fadeIn 2s forwards;
+  }
+
+  #final-score {
+    margin-top: 20px;
+    font-size: 32px;
+  }
+
+  #restart-button, #title-button {
+    margin-top: 20px;
+    font-size: 24px;
+    padding: 10px 20px;
+    cursor: pointer;
+  }
+
+  #overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: black;
+    opacity: 0;
+    z-index: 15;
+    pointer-events: none;
+  }
+
+  .flash {
+    animation: flashFade 1s forwards;
+  }
+
+  @keyframes flashFade {
+    0% { background: white; opacity: 1; }
+    100% { background: black; opacity: 1; }
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
   }
 
   .item {


### PR DESCRIPTION
## Summary
- Add overlay, final score display, and restart/title buttons for a dramatic GAME OVER sequence
- Implement player death explosion and centralize player and UI layout
- Introduce restart logic to reset stages, score, and boss countdown

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `node script.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68934219a3b483308c419bc280d2389e