### PR TITLE
Improve mobile retry handling and balance boss in JS game

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
   <!-- スタート画面 -->
   <div id="start-screen">
     <h1>ギャラクシー<br>ストライカーX</h1>
+    <p id="instructions">操作: ←→キーで移動 / Spaceでショット</p>
+    <label for="difficulty">難易度:</label>
+    <select id="difficulty">
+      <option value="easy">EASY</option>
+      <option value="normal" selected>NORMAL</option>
+      <option value="hard">HARD</option>
+    </select>
     <button id="start-button">スタート</button>
   </div>
 
@@ -18,6 +25,7 @@
     <div id="score">Score: 0</div>
     <div id="stage">Stage: 1</div>
     <div id="countdown"></div>
+    <button id="bgm-toggle">BGM: ON</button>
     <div id="overlay"></div>
     <div id="player"></div>
     <div id="game-over">

--- a/style.css
+++ b/style.css
@@ -19,6 +19,16 @@ body {
     z-index: 999;
   }
 
+  #instructions {
+    margin-top: 20px;
+    font-size: 24px;
+  }
+
+  #difficulty {
+    margin-top: 10px;
+    font-size: 24px;
+  }
+
   #start-screen h1 {
     font-size: 100px;
     color: #ffcc00;
@@ -155,6 +165,15 @@ body {
     font-size: 20px;
     z-index: 10;
   }
+
+  #bgm-toggle {
+    position: absolute;
+    top: 40px;
+    right: 20px;
+    z-index: 10;
+    padding: 5px 10px;
+    font-size: 16px;
+  }
   
   #game-over {
     display: none;
@@ -262,5 +281,14 @@ body {
     width: 30px;
     height: 12px;
     background: red;
+  }
+
+  .boss.warning {
+    animation: bossFlash 0.5s steps(2, start);
+  }
+
+  @keyframes bossFlash {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
   }
   


### PR DESCRIPTION
## Summary
- Fix mobile restart by skipping touch handlers over the game-over layer and binding touch events to restart and title buttons
- Add difficulty selection, BGM toggle, and high-score messaging for clearer UI
- Introduce boss HP with telegraphed attacks to reduce early-game difficulty

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689471c86aec8330a5c23552399bc6b6