### PR TITLE
Play boss music during boss fights

### DIFF
--- a/script.js
+++ b/script.js
@@ -475,6 +475,7 @@ function checkBulletCollision(bullet, interval, type) {
           let points = 1000;
           bossBattle = false;
           setScrolling(true);
+          playBGM('battle_bgm.mp3');
           stage++;
           stageDisplay.textContent = `Stage: ${stage}`;
           bossCountdown = 60;
@@ -623,6 +624,7 @@ function startBossCountdown() {
       clearInterval(bossInterval);
       countdownDisplay.textContent = 'Boss Battle!';
       bossBattle = true;
+      playBGM('boss_bgm.mp3');
       spawnBoss();
     }
   }, 1000);


### PR DESCRIPTION
## Summary
- Use dedicated boss battle BGM when the boss fight starts
- Restore normal battle BGM after defeating the boss
- Rename `audio/mofumofu.mp3` to `audio/boss_bgm.mp3`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897377f6d0c8330ab42c5bc6e7030f0