### PR TITLE
Add device selection and mobile button controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,15 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
+  <!-- デバイス選択 -->
+  <div id="device-select">
+    <h2>プレイ環境を選択</h2>
+    <button id="pc-button">パソコン</button>
+    <button id="mobile-button">携帯</button>
+  </div>
+
   <!-- スタート画面 -->
-  <div id="start-screen">
+  <div id="start-screen" style="display: none;">
     <h1>ギャラクシー<br>ストライカーX</h1>
     <p id="instructions">操作: ←→キーで移動 / Spaceでショット</p>
     <label for="difficulty">難易度:</label>
@@ -35,6 +42,15 @@
       <button id="title-button">タイトルに戻る</button>
     </div>
     <audio id="bgm" loop></audio>
+
+    <!-- スマホ用ボタン操作 -->
+    <div id="mobile-controls">
+      <div id="move-buttons">
+        <button id="btn-left">←</button>
+        <button id="btn-right">→</button>
+      </div>
+      <button id="btn-shoot">●</button>
+    </div>
   </div>
 
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -12,6 +12,17 @@ const startButton = document.getElementById('start-button');
 const background = document.getElementById('background');
 const overlay = document.getElementById('overlay');
 const bgmToggle = document.getElementById('bgm-toggle');
+const deviceSelect = document.getElementById('device-select');
+const pcButton = document.getElementById('pc-button');
+const mobileButton = document.getElementById('mobile-button');
+const instructions = document.getElementById('instructions');
+const mobileControls = document.getElementById('mobile-controls');
+const btnLeft = document.getElementById('btn-left');
+const btnRight = document.getElementById('btn-right');
+const btnShoot = document.getElementById('btn-shoot');
+
+let controlMode = 'pc';
+let useSwipeControls = false;
 
 let difficulty = 'normal';
 let bossHPBase = 100;
@@ -30,6 +41,37 @@ function playBGM(file, loop = true) {
 
 // Title screen BGM
 playBGM('title_bgm.mp3');
+
+pcButton.addEventListener('click', () => {
+  controlMode = 'pc';
+  instructions.textContent = '操作: ←→キーで移動 / Spaceでショット';
+  deviceSelect.style.display = 'none';
+  startScreen.style.display = 'flex';
+});
+
+mobileButton.addEventListener('click', () => {
+  controlMode = 'mobile';
+  instructions.textContent = '操作: ボタンで移動 / ショット';
+  deviceSelect.style.display = 'none';
+  startScreen.style.display = 'flex';
+});
+
+function setupMobileButtons() {
+  const startMove = (key) => (e) => { e.preventDefault(); e.stopPropagation(); keys[key] = true; };
+  const stopMove = (key) => (e) => { e.preventDefault(); e.stopPropagation(); keys[key] = false; };
+  btnLeft.addEventListener('touchstart', startMove('ArrowLeft'), { passive: false });
+  btnLeft.addEventListener('touchend', stopMove('ArrowLeft'));
+  btnLeft.addEventListener('mousedown', startMove('ArrowLeft'));
+  btnLeft.addEventListener('mouseup', stopMove('ArrowLeft'));
+  btnRight.addEventListener('touchstart', startMove('ArrowRight'), { passive: false });
+  btnRight.addEventListener('touchend', stopMove('ArrowRight'));
+  btnRight.addEventListener('mousedown', startMove('ArrowRight'));
+  btnRight.addEventListener('mouseup', stopMove('ArrowRight'));
+  btnShoot.addEventListener('touchstart', (e) => { e.preventDefault(); e.stopPropagation(); shoot('normal'); }, { passive: false });
+  btnShoot.addEventListener('mousedown', (e) => { e.preventDefault(); e.stopPropagation(); shoot('normal'); });
+}
+
+setupMobileButtons();
 
 // ==== SVG キャッシュ機構 ====
 const svgCache = {};
@@ -133,6 +175,11 @@ function startGame() {
   overlay.style.display = 'none';
   overlay.classList.remove('flash');
   gameContainer.style.display = 'block';
+  if (controlMode === 'mobile') {
+    mobileControls.style.display = 'block';
+  } else {
+    mobileControls.style.display = 'none';
+  }
   scoreDisplay.style.display = 'block';
   stageDisplay.style.display = 'block';
   document.getElementById('countdown').style.display = 'block';
@@ -209,13 +256,13 @@ document.addEventListener('keyup', (e) => {
 
 // ==== スマホ：スワイプ上下移動／タップ発射 ====
 gameContainer.addEventListener('touchstart', (e) => {
-  if (e.target.closest('#game-over')) return;
+  if (!useSwipeControls || e.target.closest('#mobile-controls') || e.target.closest('#game-over')) return;
   e.preventDefault();
   touchStartY = e.touches[0].clientY;
   touchStartX = e.touches[0].clientX;
 }, { passive: false });
 gameContainer.addEventListener('touchmove', (e) => {
-  if (e.target.closest('#game-over')) return;
+  if (!useSwipeControls || e.target.closest('#mobile-controls') || e.target.closest('#game-over')) return;
   e.preventDefault();
   const currentY = e.touches[0].clientY;
   const currentX = e.touches[0].clientX;
@@ -233,7 +280,7 @@ gameContainer.addEventListener('touchmove', (e) => {
   touchStartX = currentX;
 }, { passive: false });
 gameContainer.addEventListener('touchend', (e) => {
-  if (e.target.closest('#game-over')) return;
+  if (!useSwipeControls || e.target.closest('#mobile-controls') || e.target.closest('#game-over')) return;
   e.preventDefault();
   shoot('normal');
 }, { passive: false });
@@ -764,6 +811,9 @@ function updateScore(amount) {
 function endGame() {
   if (gameOver) return;
   gameOver = true;
+  if (controlMode === 'mobile') {
+    mobileControls.style.display = 'none';
+  }
   setScrolling(false);
   scoreDisplay.style.display = 'none';
   stageDisplay.style.display = 'none';

--- a/style.css
+++ b/style.css
@@ -5,7 +5,27 @@ body {
     background-color: black;
     color: white;
   }
-  
+
+#device-select {
+    position: fixed;
+    top: 0; left: 0;
+    width: 100vw; height: 100vh;
+    background: black;
+    color: white;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+  }
+
+#device-select button {
+    margin: 20px;
+    padding: 20px 40px;
+    font-size: 32px;
+    cursor: pointer;
+  }
+
   #start-screen {
     position: fixed;
     top: 0; left: 0;
@@ -54,6 +74,38 @@ body {
     overflow: hidden;
     display: none;
     touch-action: none;
+  }
+
+  #mobile-controls {
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    display: none;
+    pointer-events: none;
+  }
+
+  #mobile-controls button {
+    width: 60px;
+    height: 60px;
+    font-size: 24px;
+    opacity: 0.7;
+    pointer-events: auto;
+  }
+
+  #move-buttons {
+    position: absolute;
+    left: 20px;
+    bottom: 20px;
+  }
+
+  #move-buttons button {
+    margin-right: 10px;
+  }
+
+  #btn-shoot {
+    position: absolute;
+    right: 20px;
+    bottom: 20px;
   }
   
   #background {


### PR DESCRIPTION
## Summary
- Add a device-selection screen to choose between PC and mobile play.
- Implement on-screen buttons for mobile control and update scripts to manage button input.
- Style new selection and control elements for proper display.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c679ad9c833085033a34d0c1efda