### PR TITLE
Boost player craft reaction speed

### DIFF
--- a/script.js
+++ b/script.js
@@ -184,7 +184,7 @@ const ITEM_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50 50">
 
 let playerY = window.innerHeight / 2;
 let playerX = window.innerWidth * 0.2;
-const speed = 5;
+const speed = 5 * 1000;
 let keys = {};
 let score = 0;
 let gameOver = false;


### PR DESCRIPTION
## Summary
- Multiply player movement speed by 1000 for quicker response

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7720b66508330be109eeb968a54cd